### PR TITLE
Add orders queue and associated configuration

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -15,6 +15,7 @@ param storageAccountName string = 'toylaunch${uniqueString(resourceGroup().id)}'
 param environmentType string
 
 var storageAccountSkuName = (environmentType == 'prod') ? 'Standard_GRS' : 'Standard_LRS'
+var processOrderQueueName = 'processorder'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   name: storageAccountName
@@ -26,6 +27,13 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   properties: {
     accessTier: 'Hot'
   }
+  resource queueServices 'queueServices' existing = {
+    name: 'default'
+
+    resource processOrderQueue 'queues' = {
+      name: processOrderQueueName
+    }
+  }
 }
 
 module appService 'modules/appService.bicep' = {
@@ -33,6 +41,8 @@ module appService 'modules/appService.bicep' = {
   params: {
     location: location
     appServiceAppName: appServiceAppName
+    storageAccountName: storageAccount.name
+    processOrderQueueName: storageAccount::queueServices::processOrderQueue.name
     environmentType: environmentType
   }
 }

--- a/deploy/modules/appService.bicep
+++ b/deploy/modules/appService.bicep
@@ -4,6 +4,12 @@ param location string
 @description('The name of the App Service app to deploy. This name must be globally unique.')
 param appServiceAppName string
 
+@description('The name of the storage account to deploy. This name must be globally unique.')
+param storageAccountName string
+
+@description('The name of the queue to deploy for processing orders.')
+param processOrderQueueName string
+
 @description('The type of the environment. This must be nonprod or prod.')
 @allowed([
   'nonprod'
@@ -28,7 +34,19 @@ resource appServiceApp 'Microsoft.Web/sites@2022-03-01' = {
   properties: {
     serverFarmId: appServicePlan.id
     httpsOnly: true
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'StorageAccountName'
+          value: storageAccountName
+        }
+        {
+          name: 'ProcessOrderQueueName'
+          value: processOrderQueueName
+        }
+      ]
+    }
   }
-}
+ }
 
 output appServiceAppHostName string = appServiceApp.properties.defaultHostName


### PR DESCRIPTION
This PR adds a new Azure Storage queue for processing orders, and updates the website configuration to include the storage account and queue information.